### PR TITLE
Better debouncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Can be used to detect key press events that were assigned distinctive levels of 
 * [Reference](#reference)
 * [Examples](#examples)
 * [License](#license)
+* [**Wiki**](https://github.com/Spirik/KeyDetector/wiki)
 
 When to use
 -----------
@@ -29,7 +30,7 @@ How to use
 Library format is compatible with Arduino IDE 1.5.x+. There are two ways to install the library:
 
 - Download ZIP-archive directly from [Releases](https://github.com/Spirik/KeyDetector/releases) section (or Master branch) and extract it into KeyDetector folder inside your Library folder.
-- Using Library Manager (since Arduino IDE 1.6.2): navigate to `Sketch > Include Library > Manage Libraries` inside your Arduino IDE and search for KeyDetector library then click `Install`. (Alternatively you can add previously downloaded ZIP through `Sketch > Include Library > Add .ZIP Library` menu).
+- Using Library Manager (since Arduino IDE 1.6.2): navigate to `Sketch > Include Library > Manage Libraries` inside your Arduino IDE and search for KeyDetector library, then click `Install`. (Alternatively you can add previously downloaded ZIP through `Sketch > Include Library > Add .ZIP Library` menu).
 
 Whichever option you choose you may need to reload IDE afterwards.
 
@@ -38,7 +39,7 @@ Whichever option you choose you may need to reload IDE afterwards.
 To include KeyDetector library add the following line at the top of your sketch:
 
 ```cpp
-#include "KeyDetector.h”
+#include <KeyDetector.h>
 ```
 
 ### Use
@@ -173,7 +174,7 @@ Key myKeyDigital = {KEY_ID, keyPin}; //For digital pin
 Class responsible for watching for desired level of signal to occur on specified pin. Holds current and previously detected key/signal identifier. Object of class `KeyDetector` defines as follows:
 
 ```cpp
-KeyDetector myKeyDetector(keysArray, keysArrayLength, analogDelay, analogThreshold);
+KeyDetector myKeyDetector(keysArray, keysArrayLength, debounceDelay, analogThreshold);
 ```
 
 * **keysArray**  
@@ -182,11 +183,11 @@ KeyDetector myKeyDetector(keysArray, keysArrayLength, analogDelay, analogThresho
 * **keysArrayLength**  
   *Type*: `byte`  
   Length of `keysArray`. Should be explicitly supplied because array is passed by reference. Easy way to provide array length is to calculate it using the following expression: `sizeof(keysArray)/sizeof(Key)`.
-* **analogDelay** [*optional*]  
+* **debounceDelay** [*optional*]  
   *Type*: `byte`  
   *Units*: ms  
   *Default*: `0`  
-  Delay in ms to account for any transient process that may occur when adjusting the source level of analog signal on transmitting end. Try increasing this value if you are experiencing detection of undesired adjacent signals prior to the detection of the actual signal you're sending. For example, that may be the case when you are using low-pass RC filter on transmitting end to convert PWM signal into analog (due to the temporal nature of the process).
+  Delay in ms to account for any signal ripple (e.g. switch bounce) when detecting digital signal, or transient process that may occur when adjusting the source level of analog signal on transmitting end. Try increasing this value if you are experiencing detection of undesired adjacent signals prior to the detection of the actual signal you're sending. For example, that may be the case when you are using low-pass RC filter on transmitting end to convert PWM signal into analog (due to the temporal nature of the process).
 * **analogThreshold** [*optional*]  
   *Type*: `int`  
   *Default*: `16`  

--- a/examples/Example-01_Analog/Example-01_Analog.ino
+++ b/examples/Example-01_Analog/Example-01_Analog.ino
@@ -35,7 +35,7 @@ Key keys[] = {{KEY_25, potPin, 255}, {KEY_50, potPin, 511}, {KEY_75, potPin, 767
 // Create KeyDetector object
 KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key), 0, 129);
 // Notes:
-// Increasing of 'analogDelay' can cause skip of detection of adjacent values if pot is rotated quickly enough, but helps
+// Increasing of 'debounceDelay' (set to 0) can cause skip of detection of adjacent values if pot is rotated quickly enough, but helps
 // to account for any transient processes or ripple that may occur during pot rotation and value readings, try value of 1
 // as an alternative to the delay set at the end of the loop().
 // Value of 'analogThreshold' is set to 129 so that there are no gaps between detection ranges of signals,
@@ -83,6 +83,6 @@ void loop() {
   }
 
   // Small delay to account for any transient processes or ripple that may occur during pot rotation and value readings.
-  // Alternatively can be adjusted through analogDelay parameter supplied to KeyDetector constructor
+  // Alternatively can be adjusted through debounceDelay parameter supplied to KeyDetector constructor
   delay(2);
 }

--- a/examples/Example-02_Digital/Example-02_Digital.ino
+++ b/examples/Example-02_Digital/Example-02_Digital.ino
@@ -33,6 +33,9 @@ Key keys[] = {{KEY_A, pinA}, {KEY_B, pinB}, {KEY_C, pinC}};
 
 // Create KeyDetector object
 KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key));
+// To account for switch bounce effect of the buttons (if occur) you may whant to specify debounceDelay
+// as the second argument to KeyDetector constructor:
+// KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key), 10);
 
 void setup() {
   Serial.begin(115200);

--- a/examples/Example-03_Multiplexed/Example-03-2_Demux/Example-03-2_Demux.ino
+++ b/examples/Example-03_Multiplexed/Example-03-2_Demux/Example-03-2_Demux.ino
@@ -44,6 +44,9 @@ KeyDetector key(keys, sizeof(keys)/sizeof(Key));
 // or inaccuracy of the DAC used to encode signals). To do so, use the following line instead (where 24 is the custom
 // value of threshold):
 // KeyDetector key(keys, sizeof(keys)/sizeof(Key), 0, 24);
+// Additionally you can specify debounceDelay value to account for any transient process that may occur when adjusting
+// the source level of analog signal:
+// KeyDetector key(keys, sizeof(keys)/sizeof(Key), 5, 24);
 
 void setup() {
   // Configure the reference voltage used for analog input (i.e. the value used as the top of the input range)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=KeyDetector
-version=1.0.0
+version=1.1.0
 author=Alexander 'Spirik' Spiridonov <alexander.spirik@gmail.com>
 maintainer=Alexander 'Spirik' Spiridonov <alexander.spirik@gmail.com>
 sentence=A library for detecting state change on analog and digital pins.

--- a/src/KeyDetector.h
+++ b/src/KeyDetector.h
@@ -10,7 +10,8 @@
   For documentation visit:
   https://github.com/Spirik/KeyDetector
 
-  Created by Alexander 'Spirik' Spiridonov, 11 July 2016
+  Created by Alexander 'Spirik' Spiridonov, 11 Jul 2016
+  Updated 29 Oct 2017
   
   This is free software. You can redistribute it and/or modify it under
   the terms of Creative Commons Attribution-ShareAlike 4.0 International License.
@@ -39,13 +40,14 @@ class KeyDetector {
     /* 
       @param 'keys' - array of the Key elements
       @param 'len' - length of the 'keys' array
-      @param 'analogDelay' (optional) - delay in ms to account for any transient process that may occur when adjusting the source level of analog signal;
+      @param 'debounceDelay' (optional) - delay in ms to account for any signal ripple (e.g. switch bounce) when detecting digital signal,
+      or transient process that may occur when adjusting the source level of analog signal
       default 0
       @param 'analogThreshold' (optional) - value added to and subtracted from the level value of the multiplexed Key,
-      formed range [level - analogThreshold + 1 .. level + analogThreshold - 1] is then used to detect key press event;
+      formed range [level - analogThreshold + 1 .. level + analogThreshold - 1] is then used to detect key press event
       default 16 (which allows for maximum of 32 keys multiplexed via 5-bit DAC into single analog line with 10-bit ADC on the Arduino end)
     */
-    KeyDetector(Key* keys, byte len, byte analogDelay = 0, int analogThreshold = 16);
+    KeyDetector(Key* keys, byte len, byte debounceDelay = 0, int analogThreshold = 16);
     byte trigger = KEY_NONE;    // Identifier of key being pressed (triggers ones at the beginning of press event)
     byte current = KEY_NONE;    // Identifier of key currently in pressed state
     byte previous = KEY_NONE;   // Identifier of previously pressed key
@@ -53,8 +55,8 @@ class KeyDetector {
   private:
     Key* _keys;
     byte _len;
+    byte _debounceDelay;
     int _analogThreshold;
-    byte _analogDelay;
 };
   
 #endif


### PR DESCRIPTION
Updates:
* `analogDelay` and `_analogDelay` renamed to `debounceDelay` and `_debounceDelay`;
* added debouncing for digital signal detection;
* updated debouncing (former `analogDelay`) for analog signal detection;
* examples updated accordingly;
* readme updated accordingly;
* version bumped to 1.1.0.

Fully compatible with previous version (1.0.0).